### PR TITLE
chore: temporarily stop building for windows 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ jobs:
             target: aarch64-apple-darwin
             binary_name: dfrun
             archive_name: dfrun-macos-arm64.tar.gz
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            binary_name: dfrun.exe
-            archive_name: dfrun-windows-x86_64.zip
+          # - os: windows-latest
+          #   target: x86_64-pc-windows-msvc
+          #   binary_name: dfrun.exe
+          #   archive_name: dfrun-windows-x86_64.zip
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
since we don't have any usage yet, and windows build take significantly longer than other platforms. 

![Screenshot 2025-04-02 at 11 13 51 AM](https://github.com/user-attachments/assets/be5d3f91-ec5c-49bf-8653-10648d5c3d94)
